### PR TITLE
enhance gisign script to check availability of tlog index

### DIFF
--- a/scripts/check_gitsign.sh
+++ b/scripts/check_gitsign.sh
@@ -1,19 +1,16 @@
 #!/bin/bash
 
-# Pre-commit hook to check if the latest commit is signed using gitsign
+# Pre-commit hook to check if last commit was signed using gitsign and contains a valid tlog index
 
 # Get the hash of the latest commit
 latest_commit=$(git rev-parse HEAD)
 
-# Check if the latest commit is signed
-signed_commit=$(git verify-commit $latest_commit 2>&1)
-
-# Check for a valid signature
-if [[ $signed_commit == *"Validated Git signature: true"* ]]; then
-    echo "Latest commit is signed with gitsign."
+# Check if the latest commit is signed and contains a valid tlog index
+if [[ $(git verify-commit $latest_commit 2>&1) == *"Validated Git signature: true"* && $(git verify-commit $latest_commit 2>&1) == *"tlog index: "*[0-9]* ]]; then
+    echo "Latest commit is signed with gitsign and contains a valid tlog index."
+    exit 0
 else
-    echo "WARNING: The latest commit is not signed with gitsign."
-    # Optionally, you can uncomment the next line to block the commit
+    echo "WARNING: The latest commit is either not signed with gitsign or does not contain a valid tlog index."
     exit 1
 fi
 


### PR DESCRIPTION
Enhance the script to check if the last commit was signed using gitsign.

This script now checks for a `tlog:` entry to be available when `git verify-commit HEAD` is run.